### PR TITLE
python 3 (and backports.configparser) fixes

### DIFF
--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -8,10 +8,15 @@ from bucko.repo_compose import RepoCompose
 from bucko.publisher import Publisher
 from bucko.koji_builder import KojiBuilder
 try:
-    from configparser import ConfigParser
+    import configparser
+    ConfigParserError = configparser.Error
 except ImportError:
     import ConfigParser
-
+    ConfigParserError = ConfigParser.Error
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser
 
 __version__ = '1.0.0'
 
@@ -83,7 +88,7 @@ def compose_url_from_env():
 
 def config():
     """ Load a bucko configuration file and return a ConfigParser object. """
-    configp = ConfigParser.ConfigParser()
+    configp = ConfigParser()
     configp.read(['bucko.conf', os.path.expanduser('~/.bucko.conf')])
     return configp
 
@@ -99,7 +104,7 @@ def lookup(configp, section, option, fatal=True):
     """ Gracefully (or not) look up an option from a ConfigParser section. """
     try:
         return configp.get(section, option)
-    except ConfigParser.Error as e:
+    except ConfigParserError as e:
         if fatal:
             raise SystemExit('Problem parsing .bucko.conf: %s' % e.message)
 

--- a/bucko/publisher.py
+++ b/bucko/publisher.py
@@ -1,5 +1,8 @@
 import posixpath
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 import os
 from paramiko import SSHClient
 import shutil

--- a/bucko/repo_compose.py
+++ b/bucko/repo_compose.py
@@ -125,6 +125,6 @@ class RepoCompose(productmd.compose.Compose):
                 config.set(name, 'gpgcheck', 1)
                 config.set(name, 'gpgkey', self.keys[bp.gpgkey])
 
-        with open(filename, 'wb') as configfile:
+        with open(filename, 'w') as configfile:
             config.write(configfile)
         return filename

--- a/bucko/repo_compose.py
+++ b/bucko/repo_compose.py
@@ -3,9 +3,9 @@ import posixpath
 import tempfile
 import productmd.compose
 try:
-    from configparser import ConfigParser
+    from configparser import RawConfigParser
 except ImportError:
-    import ConfigParser
+    from ConfigParser import RawConfigParser
 
 # Default set of GPG signing keys:
 GPG_KEYS = {
@@ -75,7 +75,7 @@ class RepoCompose(productmd.compose.Compose):
         """
         filename = '%s.repo' % self.info.compose.id
         filename = os.path.join(tempfile.mkdtemp(suffix='.compose'), filename)
-        config = ConfigParser.RawConfigParser()
+        config = RawConfigParser()
         try:
             variants = self.info.get_variants(arch=arch)
         except AttributeError:

--- a/bucko/tests/test_init.py
+++ b/bucko/tests/test_init.py
@@ -4,7 +4,7 @@ import bucko
 try:
     from configparser import ConfigParser
 except ImportError:
-    import ConfigParser
+    from ConfigParser import ConfigParser
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
@@ -48,7 +48,7 @@ class TestComposeUrlFromEnv(object):
 class TestGetPublisher(object):
     @pytest.fixture
     def config(self):
-        config = ConfigParser.ConfigParser()
+        config = ConfigParser()
         config.add_section('publish')
         config.set('publish', 'push', 'file:///mypath')
         config.set('publish', 'http', 'http:///example.com/mypath')
@@ -64,7 +64,7 @@ class TestGetPublisher(object):
 class TestGetCompose(object):
     @pytest.fixture
     def config(self):
-        config = ConfigParser.ConfigParser()
+        config = ConfigParser()
         config.add_section('keys')
         branch = 'myproduct-2.1-rhel-7'
         config.add_section(branch + '-base')
@@ -95,7 +95,7 @@ class FakeKojiBuilder(object):
 class TestBuildContainer(object):
     @pytest.fixture
     def config(self):
-        config = ConfigParser.ConfigParser()
+        config = ConfigParser()
         config.add_section('koji')
         config.set('koji', 'hub', 'dummyhub')
         config.set('koji', 'web', 'dummyweb')

--- a/bucko/tests/test_repo_compose.py
+++ b/bucko/tests/test_repo_compose.py
@@ -4,8 +4,10 @@ import productmd.compose
 import pytest
 try:
     from configparser import ConfigParser
+    from configparser import RawConfigParser
 except ImportError:
     import ConfigParser
+    from ConfigParser import RawConfigParser
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_DIR = os.path.join(TESTS_DIR, 'fixtures')
@@ -73,7 +75,7 @@ class TestRepoComposeYumRepo(object):
     def test_file_contents(self, repocompose):
         path = repocompose.write_yum_repo_file()
         # Verify the contents with ConfigParser
-        config = ConfigParser.RawConfigParser()
+        config = RawConfigParser()
         config.read(path)
         expected = ['MYPRODUCT-2.1-RHEL-7-MON',
                     'MYPRODUCT-2.1-RHEL-7-OSD',
@@ -85,14 +87,14 @@ class TestRepoComposeYumRepo(object):
         # No gpgkey means gpgcheck should be 0 in the .repo file.
         assert repocompose.info.base_product.gpgkey is None
         path = repocompose.write_yum_repo_file()
-        config = ConfigParser.RawConfigParser()
+        config = RawConfigParser()
         config.read(path)
         assert config.get('rhel-7', 'gpgcheck') == '0'
 
     def test_base_product_gpgkey(self, repocompose_bp_signed):
         # gpgkey is set, so it will be present in the .repo file.
         path = repocompose_bp_signed.write_yum_repo_file()
-        config = ConfigParser.RawConfigParser()
+        config = RawConfigParser()
         config.read(path)
         assert config.get('rhel-7', 'gpgcheck') == '1'
         assert config.get('rhel-7', 'gpgkey') == '/etc/RPM-GPG-KEY-f00d'
@@ -100,7 +102,7 @@ class TestRepoComposeYumRepo(object):
     def test_base_product_extras(self, repocompose_extras):
         # extras is set, so it will be present in the .repo file.
         path = repocompose_extras.write_yum_repo_file()
-        config = ConfigParser.RawConfigParser()
+        config = RawConfigParser()
         config.read(path)
         assert config.get('rhel-7-extras', 'gpgcheck') == '1'
         assert config.get('rhel-7-extras', 'gpgkey') == '/etc/RPM-GPG-KEY-f00d'


### PR DESCRIPTION
Fix Python 3 support. This also fixes the tests on the latest Python in Fedora, where we have backports.configparser.