### PR TITLE
get_branch: support RHEL 8-based composes

### DIFF
--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -111,7 +111,13 @@ def get_compose(compose_url, configp):
 
 
 def get_branch(compose):
-    """ Return a dist-git branch name for this compose. """
+    """
+    Return a dist-git branch name for this compose.
+
+    Examples:
+      "ceph-2-rhel-7"
+      "ceph-3.2-rhel-7"
+    """
     name = compose.info.release.short.lower()
     if name == 'rhceph':
         name = 'ceph'

--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -117,6 +117,7 @@ def get_branch(compose):
     Examples:
       "ceph-2-rhel-7"
       "ceph-3.2-rhel-7"
+      "ceph-4.0-rhel-8"
     """
     name = compose.info.release.short.lower()
     if name == 'rhceph':
@@ -125,7 +126,9 @@ def get_branch(compose):
     if name == 'ceph' and version.startswith('2'):
         # special-case ceph 2.y branch names
         version = 2
-    return '%s-%s-rhel-7' % (name, version)
+    bp_short = compose.info.base_product.short.lower()  # "rhel"
+    bp_version = compose.info.base_product.version  # "7" or "8"
+    return '%s-%s-%s-%s' % (name, version, bp_short, bp_version)
 
 
 def build_container(repo_urls, branch, parent_image, configp):

--- a/bucko/tests/test_init.py
+++ b/bucko/tests/test_init.py
@@ -84,6 +84,11 @@ class TestGetBranch(object):
         branch = bucko.get_branch(compose)
         assert branch == 'myproduct-2.1-rhel-7'
 
+    def test_get_branch_rhel_8(self, compose):
+        compose.info.base_product.version = '8'
+        branch = bucko.get_branch(compose)
+        assert branch == 'myproduct-2.1-rhel-8'
+
 
 class FakeKojiBuilder(object):
     """ Dummy KojiBuilder module """

--- a/bucko/tests/test_init.py
+++ b/bucko/tests/test_init.py
@@ -1,4 +1,5 @@
 import os
+import productmd
 import pytest
 import bucko
 try:
@@ -71,6 +72,17 @@ class TestGetCompose(object):
     def test_get_compose(self, config):
         c = bucko.get_compose(FIXTURES_DIR, config)
         assert isinstance(c, bucko.RepoCompose)
+
+
+class TestGetBranch(object):
+    @pytest.fixture
+    def compose(self):
+        compose_obj = productmd.compose.Compose(FIXTURES_DIR)
+        return compose_obj
+
+    def test_get_branch_basic(self, compose):
+        branch = bucko.get_branch(compose)
+        assert branch == 'myproduct-2.1-rhel-7'
 
 
 class FakeKojiBuilder(object):


### PR DESCRIPTION
Prior to this change, we were hard-coding "rhel-7" as the dist-git branch suffix for all composes.

RH Ceph Storage 4 will be based on RHEL 8, so this will not work. We must determine the dist-git branch name suffix from the [composeinfo's BaseProduct](https://productmd.readthedocs.io/en/latest/composeinfo.html#productmd.composeinfo.BaseProduct) information.