### PR TITLE
add koji to setuptools requirements, and add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+dist: xenial
+language: python
+sudo: false
+python:
+  - 2.7
+install:
+  # koji requires requests, but Travis CI has trouble installing this for an
+  # unknown reason. To fix this, we install requests first here.
+  - pip install requests
+  - python setup.py develop
+script:
+  - py.test -v bucko/tests
+cache: pip
+addons:
+  apt:
+    packages:
+    - rpm
+    - librpm-dev

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     license='GPLv2',
     include_package_data=True,
     install_requires=[
-        # 'koji', it's a requirement, but we can't specify it here. :(
+        'koji',
         'paramiko',
         'productmd>=1.3',
     ],


### PR DESCRIPTION
Add "koji" to the list of modules setuptools will require.

Add configuration for Travis CI to run the test suite on Python 2. (Python 3 is failing at the moment, something related to rpm-py-installer on py3 on Xenial.)