### PR TITLE
clean up old references

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,7 +194,7 @@ Sample ``bucko.conf`` contents::
     [koji]
     hub = https://koji.fedoraproject.org/kojihub
     web = http://koji.fedoraproject.org/koji
-    scm = git://example.com/containers/rhceph-rhel7#origin/%(branch)s
+    scm = git://example.com/containers/rhceph#origin/%(branch)s
     target = %(branch)s-containers-candidate
     krbservice = brewhub
 

--- a/README.rst
+++ b/README.rst
@@ -204,7 +204,7 @@ Sample ``bucko.conf`` contents::
 
     [registry]
     # container registry with tags for parent images
-    url = http://pulp-docker01.example.com:8888
+    url = https://registry-proxy.example.com
 
     [ceph-3.0-rhel-7-base]
     # HTTP URLs to RHEL 7 Server and RHEL 7 Extras Yum .repo files

--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -115,7 +115,6 @@ def get_branch(compose):
     Return a dist-git branch name for this compose.
 
     Examples:
-      "ceph-2-rhel-7"
       "ceph-3.2-rhel-7"
       "ceph-4.0-rhel-8"
     """
@@ -123,9 +122,6 @@ def get_branch(compose):
     if name == 'rhceph':
         name = 'ceph'
     version = compose.info.release.version
-    if name == 'ceph' and version.startswith('2'):
-        # special-case ceph 2.y branch names
-        version = 2
     bp_short = compose.info.base_product.short.lower()  # "rhel"
     bp_version = compose.info.base_product.version  # "7" or "8"
     return '%s-%s-%s-%s' % (name, version, bp_short, bp_version)
@@ -204,7 +200,7 @@ def main():
     branch = get_branch(c)
 
     # Determine other settings for this branch
-    section = '%s-base' % branch  # eg "ceph-2-rhel-7-base"
+    section = '%s-base' % branch  # eg "ceph-4.0-rhel-8-base"
     parent_image = config.lookup(configp, section, 'parent_image', fatal=False)
     if parent_image:
         log.info('parent_image configured: %s' % parent_image)

--- a/bucko/tests/fixtures/.bucko.conf
+++ b/bucko/tests/fixtures/.bucko.conf
@@ -5,7 +5,7 @@ http = http://example.com/~kdreyer/osbs
 [koji]
 hub = https://koji.fedoraproject.org/kojihub
 web = http://koji.fedoraproject.org/koji
-scm = git://example.com/containers/rhceph-rhel7#origin/%(branch)s
+scm = git://example.com/containers/rhceph#origin/%(branch)s
 target = %(branch)s-containers-candidate
 krbservice = brewhub
 

--- a/bucko/tests/fixtures/.bucko.conf
+++ b/bucko/tests/fixtures/.bucko.conf
@@ -15,10 +15,10 @@ f000000d = http://internal.example.com/keys/RPM-GPG-KEY-internal-custom
 [registry]
 url = http://pulp-docker01.example.com:8888
 
-[ceph-2-rhel-7-base]
+[ceph-3.1-rhel-7-base]
 repo1 = http://example.com/repo1.repo
 repo2 = http://example.com/repo2.repo
 
-[ceph-3.1-rhel-7-base]
+[ceph-4.0-rhel-8-base]
 repo1 = http://example.com/repo1.repo
 repo2 = http://example.com/repo2.repo

--- a/bucko/tests/fixtures/.bucko.conf
+++ b/bucko/tests/fixtures/.bucko.conf
@@ -13,7 +13,7 @@ krbservice = brewhub
 f000000d = http://internal.example.com/keys/RPM-GPG-KEY-internal-custom
 
 [registry]
-url = http://pulp-docker01.example.com:8888
+url = https://registry-proxy.engineering.redhat.com
 
 [ceph-3.1-rhel-7-base]
 repo1 = http://example.com/repo1.repo

--- a/bucko/tests/test_config.py
+++ b/bucko/tests/test_config.py
@@ -48,7 +48,7 @@ def test_lookup_nonfatal(simple_configp):
 
 
 def test_get_repo_urls(configp):
-    section = 'ceph-2-rhel-7-base'
+    section = 'ceph-4.0-rhel-8-base'
     result = config.get_repo_urls(configp, section)
     expected = set(['http://example.com/repo1.repo',
                     'http://example.com/repo2.repo'])

--- a/bucko/tests/test_koji_builder.py
+++ b/bucko/tests/test_koji_builder.py
@@ -59,7 +59,7 @@ class TestKojiBuilder(object):
     def test_build_container(self, monkeypatch):
         monkeypatch.setattr('bucko.koji_builder.koji', FakeKoji)
         k = KojiBuilder('dummyhub', 'dummyweb', 'brewhub')
-        scm = 'git://example.com/containers/rhceph-rhel7#origin/ceph-2-rhel-7'
+        scm = 'git://example.com/containers/rhceph#origin/ceph-2-rhel-7'
         target = 'ceph-2-rhel-7-containers-candidate'
         result = k.build_container(scm, target, 'ceph-2-rhel-7', [])
         assert result == 1234

--- a/bucko/tests/test_koji_builder.py
+++ b/bucko/tests/test_koji_builder.py
@@ -59,9 +59,9 @@ class TestKojiBuilder(object):
     def test_build_container(self, monkeypatch):
         monkeypatch.setattr('bucko.koji_builder.koji', FakeKoji)
         k = KojiBuilder('dummyhub', 'dummyweb', 'brewhub')
-        scm = 'git://example.com/containers/rhceph#origin/ceph-2-rhel-7'
-        target = 'ceph-2-rhel-7-containers-candidate'
-        result = k.build_container(scm, target, 'ceph-2-rhel-7', [])
+        scm = 'git://example.com/containers/rhceph#origin/ceph-4.0-rhel-8'
+        target = 'ceph-4.0-rhel-8-containers-candidate'
+        result = k.build_container(scm, target, 'ceph-4.0-rhel-8', [])
         assert result == 1234
 
     def test_watch_task(self, monkeypatch, capsys):


### PR DESCRIPTION
Some infrastructure things have changed:

* We no longer use "rhceph-rhel7"
* ceph-2 is EOL
* We no longer use Pulp

Update the old references throughout the project so that we do not refer to these things that we no longer use.