### PR TITLE
interpolate "distro" and "distro_upper" in COMPOSE_URL

### DIFF
--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -41,10 +41,11 @@ def parse_ci_message(msg, compose_url):
     # COMPOSE_URL environment variable (format string).
     (_, version, distro) = branch.split('-', 2)
     major = int(float(version))
-    distro = distro.upper()
+    distro_upper = distro.upper()
     result = compose_url % {'branch': branch,
                             'major': major,
-                            'distro': distro}
+                            'distro': distro,
+                            'distro_upper': distro_upper}
     log.info('transformed %s format string to %s' % (compose_url, result))
     return result
 

--- a/bucko/tests/test_init.py
+++ b/bucko/tests/test_init.py
@@ -39,10 +39,10 @@ class TestComposeUrlFromEnv(object):
         assert bucko.compose_url_from_env() == 'http://foo'
 
     def test_distgit_ci_message(self, monkeypatch):
-        tmpl = 'http://foo/%(branch)s/latest-RHCEPH-%(major)s-%(distro)s'
+        tmpl = 'http://foo/%(distro)s/%(branch)s/latest-RHCEPH-%(major)s-%(distro_upper)s'
         monkeypatch.setenv('COMPOSE_URL', tmpl)
         monkeypatch.setenv('CI_MESSAGE', '{"branch": "ceph-3.0-rhel-7"}')
-        expected = 'http://foo/ceph-3.0-rhel-7/latest-RHCEPH-3-RHEL-7'
+        expected = 'http://foo/rhel-7/ceph-3.0-rhel-7/latest-RHCEPH-3-RHEL-7'
         assert bucko.compose_url_from_env() == expected
 
 


### PR DESCRIPTION
RCM stores composes in "rhel-7" or "rhel-8" directories in NFS.  This means that must interpolate the lower-case "rhel-8" string as well as the upper-case "RHEL-8" string when we determine our `COMPOSE_URL` path.

(The change of "`distro`" to lower-case technically breaks bucko's current behavior. However, with RCM's change to the new directory layout for composes, this overall functionality was was already broken.)