### PR TITLE
py3 support for write_props_file()

### DIFF
--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -100,7 +100,7 @@ def write_props_file(**kwargs):
         log.info('WORKSPACE detected, writing osbs.props for Jenkins')
         props_path = os.path.join(os.environ['WORKSPACE'], 'osbs.props')
         with open(props_path, 'w') as props:
-            for key, value in kwargs.iteritems():
+            for key, value in kwargs.items():
                 props.write(key.upper() + '=' + str(value) + "\n")
 
 

--- a/bucko/tests/test_init.py
+++ b/bucko/tests/test_init.py
@@ -125,3 +125,21 @@ class TestBuildContainer(object):
         results = bucko.build_container(repo_url, branch, parent_image, config)
         assert results['koji_task'] == 1234
         assert results['repository'] == 'http://registry.example.com/foo'
+
+
+class TestWritePropsFile(object):
+    def test_no_workspace(self, monkeypatch):
+        monkeypatch.delenv('WORKSPACE', raising=False)
+        metadata = {'foo': 'bar'}
+        # Does nothing:
+        bucko.write_props_file(**metadata)
+
+    def test_simple(self, monkeypatch, tmpdir):
+        monkeypatch.setenv('WORKSPACE', str(tmpdir))
+        metadata = {'foo': 'bar'}
+        props_path = tmpdir.join('osbs.props')
+        with tmpdir.as_cwd():
+            bucko.write_props_file(**metadata)
+        contents = props_path.read_text('utf-8')
+        expected = 'FOO=bar\n'
+        assert contents == expected


### PR DESCRIPTION
Prior to this change, `write_props_file()` would crash on Python 3 because we did not have a "iteritems" method.

```
AttributeError: 'dict' object has no attribute 'iteritems'
```

Switch to the "`items()`" method instead.

Add unit tests for the `write_props_file()` method to ensure that this works on Python 2 and 3.