### PR TITLE
container_publisher: improve backoff settings

### DIFF
--- a/bucko/container_publisher.py
+++ b/bucko/container_publisher.py
@@ -39,7 +39,10 @@ class ContainerPublisher(object):
 
     @backoff.on_exception(backoff.expo,
                           subprocess.CalledProcessError,
-                          max_tries=3)
+                          jitter=None,
+                          factor=5,
+                          max_value=60*5,
+                          max_tries=10)
     def copy(self, source, destination):
         """
         Run "skopeo copy" with retries.


### PR DESCRIPTION
We're seeing `skopeo copy` hit some very strange errors on our registry.  Re-trying the copy operation a few hours later succeeds. Try tweaking our backoff settings to see if we can improve this:

- Disable "jitter" so we can understand the time delays a bit more. The jitter value is confusing to read in the logs.

- Multiple our backoff exponent by a factor of 5. The first delay will be 5 seconds, the next one 10 seconds, the next 20 seconds, etc.

- Do not sleep more than 5 minutes between each time that we retry.

- Try a total of 10 times (instead of 3).