### PR TITLE
make registry_host setting optional

### DIFF
--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -89,7 +89,7 @@ def get_publisher(configp):
 
 def get_container_publisher(configp):
     """ Look up the registry host and token from a ConfigParser object. """
-    host = config.lookup(configp, 'publish', 'registry_host')
+    host = config.lookup(configp, 'publish', 'registry_host', fatal=False)
     if not host:
         return None
     token = config.lookup(configp, 'publish', 'registry_token', fatal=True)


### PR DESCRIPTION
Prior to this change, if bucko read a configuration file that did not have a "``registry_host``" setting, it would fail with an error:

```
Problem parsing .bucko.conf: No option 'registry_host' in section: 'publish'
```

This setting should not be mandatory. Gracefully handle the case where it is not present in the configuration file.