### PR TITLE
container_publisher: set REGISTRY_AUTH_FILE for podman

### DIFF
--- a/bucko/tests/test_container_publisher.py
+++ b/bucko/tests/test_container_publisher.py
@@ -31,12 +31,13 @@ def test_publish(monkeypatch):
     tag = 'latest'
     p.publish(source_image, namespace, repository, tag)
     expected = [
-        ('sudo', 'podman', 'login', '-p', 'abc123', '-u', 'unused',
-         'registry.example.com'),
+        ('sudo', 'REGISTRY_AUTH_FILE=/run/containers/0/auth.json', 'podman',
+         'login', '-p', 'abc123', '-u', 'unused', 'registry.example.com'),
         ('sudo', 'skopeo', 'copy',
          'docker://registry.example.com/ceph/ceph:foo',
          'docker://registry.example.com/ceph/ceph-4.0-rhel-8:latest'),
-        ('sudo', 'podman', 'logout', 'registry.example.com'),
+        ('sudo', 'REGISTRY_AUTH_FILE=/run/containers/0/auth.json', 'podman',
+         'logout', 'registry.example.com'),
     ]
     assert recorder.calls
     assert recorder.calls == expected


### PR DESCRIPTION
podman 1.6+ in RHEL 8 writes its credentials to file to `/run/user/0/containers/auth.json` by default.

skopeo only reads from `/run/containers/0/auth.json` instead. When that file is missing, skopeo errors out:

```
Error writing manifest: Error uploading manifest latest to docker-registry.example.com/ceph/ceph-4.0-rhel-8: unauthorized: authentication required
```

To work around this problem, tell podman to write to the location skopeo expects to read.

When we get more clarity in https://bugzilla.redhat.com/show_bug.cgi?id=1800815 about the expected behavior, maybe we can revert this.