### PR TITLE
koji_builder: update module comment

### DIFF
--- a/bucko/koji_builder.py
+++ b/bucko/koji_builder.py
@@ -2,7 +2,7 @@ import posixpath
 import koji
 import time
 
-""" I have a dream that one day Koji will have a usuable API """
+""" Use the Koji API to build a container image """
 
 
 class KojiBuilder(object):


### PR DESCRIPTION
It's been four years since I wrote this comment. Koji's API has improved, and I've learned a lot about it. Replace the snarky comment with a comment that simply describes what this module does.