### PR TITLE
remove py27 from CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- 2.7
 - 3.6
 install: pip install tox-travis
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, flake8
+envlist = py36, flake8
 
 [testenv]
 deps=


### PR DESCRIPTION
We always run this on RHEL 8+, so we don't need Python 2 support.