### PR TITLE
koji_builder: log in with activate_session()

### DIFF
--- a/bucko/tests/test_koji_builder.py
+++ b/bucko/tests/test_koji_builder.py
@@ -11,8 +11,8 @@ class FakeKoji(object):
         return lambda *args, **kw: None
 
     @staticmethod
-    def ClientSession(*args):
-        return FakeClientSession()
+    def ClientSession(baseurl, opts):
+        return FakeClientSession(baseurl, opts)
 
 
 class FakeSystem(object):
@@ -27,8 +27,17 @@ class FakeClientSession(object):
     system = FakeSystem()
     tasks_waited = defaultdict(int)
 
+    def __init__(self, baseurl, opts):
+        self.opts = opts
+
     def __getattr__(self, name):
         return lambda *args, **kw: None
+
+    def gssapi_login(self, *args, **kw):
+        self.logged_in = True
+
+    def getAPIVersion(self):
+        return 1
 
     def getBuildTarget(self, target):
         return {}
@@ -55,6 +64,7 @@ class TestKojiBuilder(object):
         monkeypatch.setattr('bucko.koji_builder.koji', FakeKoji)
         k = KojiBuilder('dummyhub', 'dummyweb', 'brewhub')
         k.ensure_logged_in()
+        assert k.session.logged_in is True
 
     def test_build_container(self, monkeypatch):
         monkeypatch.setattr('bucko.koji_builder.koji', FakeKoji)


### PR DESCRIPTION
The Koji developers have deprecated the `krb_login()` method, and they will remove it in Koji 1.22. Replace this with `activate_session()` so that we are compatible with all authentication mechanisms.

We do not load full options from a Koji profile yet, so we must update the opts assignment in the constructor to fill in two missing values that `activate_session()` requires, "`authtype`" and "`cert`". We can simplify this once we switch over to Koji profiles.

Update the test suite to pass "`opts`" through to our `FakeClientSession`.  Implement fake `gssapi_login()` and `getAPIVersion()` calls to satisfy `activate_session()`.