### PR TITLE
tests: simplify FakeKoji class

### DIFF
--- a/bucko/tests/test_koji_builder.py
+++ b/bucko/tests/test_koji_builder.py
@@ -4,11 +4,8 @@ from collections import defaultdict
 
 
 class FakeKoji(object):
-    """ Dummy koji module where everything is a no-op """
+    """ Dummy koji module """
     TASK_STATES = koji.TASK_STATES
-
-    def __getattr__(self, name):
-        return lambda *args, **kw: None
 
     @staticmethod
     def ClientSession(baseurl, opts):


### PR DESCRIPTION
We don't need to handle arbitrary attrs on the `FakeKoji` class. The `FakeClientSession` class already does that for us.

Remove the method and the comment that went along with that functionality.