### PR TITLE
use koji profiles

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -196,11 +196,9 @@ Sample ``bucko.conf`` contents::
     registry_token = abc123
 
     [koji]
-    hub = https://koji.fedoraproject.org/kojihub
-    web = http://koji.fedoraproject.org/koji
+    profile = mykoji
     scm = git://example.com/containers/rhceph#origin/%(branch)s
     target = %(branch)s-containers-candidate
-    krbservice = brewhub
 
     [keys]
     # List any extra keys here. For example, an internal signing key:

--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -141,15 +141,13 @@ def get_branch(compose):
 def build_container(repo_urls, branch, parent_image, configp):
     """ Build a container with Koji. """
     kconf = dict(configp.items('koji', vars={'branch': branch}))
-    koji = KojiBuilder(hub=kconf['hub'],
-                       web=kconf['web'],
-                       krbservice=kconf['krbservice'])
+    koji = KojiBuilder(profile=kconf['profile'])
     parent = None
     if parent_image:
         registry_url = config.lookup(configp, 'registry', 'url')
         registry = Registry(registry_url)
         parent = registry.build(parent_image)  # bucko.build.Build
-    log.info('Building container at %s' % kconf['hub'])
+    log.info('Building container at %s' % koji.session.baseurl)
     task_id = koji.build_container(scm=kconf['scm'],
                                    target=kconf['target'],
                                    branch=branch,

--- a/bucko/tests/fixtures/.bucko.conf
+++ b/bucko/tests/fixtures/.bucko.conf
@@ -3,11 +3,9 @@ push = sftp://example.com/home/kdreyer/public_html/osbs
 http = http://example.com/~kdreyer/osbs
 
 [koji]
-hub = https://koji.fedoraproject.org/kojihub
-web = http://koji.fedoraproject.org/koji
+profile = koji
 scm = git://example.com/containers/rhceph#origin/%(branch)s
 target = %(branch)s-containers-candidate
-krbservice = brewhub
 
 [keys]
 f000000d = http://internal.example.com/keys/RPM-GPG-KEY-internal-custom

--- a/bucko/tests/test_init.py
+++ b/bucko/tests/test_init.py
@@ -2,6 +2,7 @@ import os
 import productmd
 import pytest
 import bucko
+from types import SimpleNamespace
 try:
     from configparser import ConfigParser
 except ImportError:
@@ -92,6 +93,8 @@ class TestGetBranch(object):
 
 class FakeKojiBuilder(object):
     """ Dummy KojiBuilder module """
+    session = SimpleNamespace(baseurl='dummyhub')
+
     def __init__(self, *args, **kw):
         pass
 
@@ -110,9 +113,7 @@ class TestBuildContainer(object):
     def config(self):
         config = ConfigParser()
         config.add_section('koji')
-        config.set('koji', 'hub', 'dummyhub')
-        config.set('koji', 'web', 'dummyweb')
-        config.set('koji', 'krbservice', 'dummykrbservice')
+        config.set('koji', 'profile', 'koji')
         config.set('koji', 'scm', 'git://example.com')
         config.set('koji', 'target', 'foo-rhel-7-candidate')
         return config


### PR DESCRIPTION
Load our Koji configuration from a profile, rather than specifying the hub + web + krbservice options directly.

This simplifies the code in Bucko, relying more on Koji's own methods of configuration. It aligns Bucko with the way the koji client, rpkg, or Pungi applications work. It also makes it easier to quickly transition between different Koji environments.

This is a breaking change, because sites must specify a new `profile` setting in the `[koji]` section of bucko.conf. Bucko now ignores the old hub, web, and krbservice settings.