### PR TITLE
container_publisher: treat "skopeo copy" failures as non-fatal

### DIFF
--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -231,9 +231,10 @@ def main():
                                               dest_namespace,
                                               branch,
                                               tag)
-            # Add the new location to metadata['repositories'] so that we
-            # record it in the -osbs.json file below.
-            metadata['repositories'].append(dest_repo)
+            if dest_repo:
+                # Add the new location to metadata['repositories'] so that we
+                # record it in the -osbs.json file below.
+                metadata['repositories'].append(dest_repo)
 
     # Store and publish our information about this build
     metadata['compose_url'] = compose_url

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,6 @@ setup(
     license='GPLv2',
     include_package_data=True,
     install_requires=[
-        'backoff',
         'koji',
         'paramiko',
         'productmd>=1.3',


### PR DESCRIPTION
Prior to this change, if `skopeo copy` failed, we would retry a few times, and if it still failed, we would bail out without writing the JSON record file.

The skopeo copy step is failing frequently enough that it's time to treat this error as non-fatal.

Remove the backoff code and only try `skopeo copy` once. If it fails, log a warning message, rather than ending the entire operation. This allows us to continue on with publishing the JSON record of the image for QE to test.

Fixes: #33 