### PR TITLE
koji_builder: use koji's watch_tasks() method

### DIFF
--- a/bucko/tests/test_koji_builder.py
+++ b/bucko/tests/test_koji_builder.py
@@ -53,13 +53,18 @@ class FakeClientSession(object):
     def buildContainer(self, *args, **kw):
         return 1234
 
-    def getTaskInfo(self, id_):
+    def getTaskInfo(self, id_, request=False):
         """ Return 'OPEN' state the first couple of times, then 'CLOSED'. """
+        task = {'host_id': None}
         self.tasks_waited[id_] += 1
         if self.tasks_waited[id_] < 5:
-            return {'state': koji.TASK_STATES['OPEN']}
+            task['state'] = koji.TASK_STATES['OPEN']
         else:
-            return {'state': koji.TASK_STATES['CLOSED']}
+            task['state'] = koji.TASK_STATES['CLOSED']
+        return task
+
+    def getTaskChildren(self, id_):
+        return []
 
 
 class TestKojiBuilder(object):


### PR DESCRIPTION
Remove our custom task watcher and use Koji's `watch_tasks()` method instead.

This simplifies the code in Bucko, relying more on Koji's own code.

Add a bit more scaffolding to `FakeClientSession` so that Koji's `watch_tasks()` method can use it.

Fixes: #25