### PR TITLE
tests: remove fake listMethods

### DIFF
--- a/bucko/tests/test_koji_builder.py
+++ b/bucko/tests/test_koji_builder.py
@@ -23,16 +23,9 @@ class FakeKoji(object):
         return cls
 
 
-class FakeSystem(object):
-    """ Dummy koji.ClientSession.system """
-    def listMethods(self):
-        return ('buildContainer')
-
-
 class FakeClientSession(object):
     """ Dummy koji.ClientSession """
     logged_in = False
-    system = FakeSystem()
     tasks_waited = defaultdict(int)
 
     def __init__(self, baseurl, opts):


### PR DESCRIPTION
Commit 05f1a8397831c49eb52e6f0af3d29b440c6466cb removed the call to listMethods. We do not need to fake it any more in the unit tests.