### PR TITLE
rename "scratch_tag" variable to "unique_tag"

### DIFF
--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -225,8 +225,8 @@ def main():
     if container_pub and 'repository' in metadata:
         source_image = metadata['repository']
         dest_namespace, _ = branch.split('-', 1)  # eg "ceph"
-        _, scratch_tag = source_image.split(':', 1)  # OSBS scratch build tag
-        for tag in ('latest', scratch_tag):
+        _, unique_tag = source_image.split(':', 1)  # OSBS unique build tag
+        for tag in ('latest', unique_tag):
             dest_repo = container_pub.publish(source_image,
                                               dest_namespace,
                                               branch,


### PR DESCRIPTION
OSBS calls this tag name a "unique" tag. It's true that this is the only tag that scratch-builds have, but now that we're not going to always scratch-build, let's use OSBS's terminology, not ours.