### PR TITLE
add --scratch flag (always True)

### DIFF
--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -138,7 +138,7 @@ def get_branch(compose):
     return '%s-%s-%s-%s' % (name, version, bp_short, bp_version)
 
 
-def build_container(repo_urls, branch, parent_image, configp):
+def build_container(repo_urls, branch, parent_image, scratch, configp):
     """ Build a container with Koji. """
     kconf = dict(configp.items('koji', vars={'branch': branch}))
     koji = KojiBuilder(profile=kconf['profile'])
@@ -152,7 +152,7 @@ def build_container(repo_urls, branch, parent_image, configp):
                                    target=kconf['target'],
                                    branch=branch,
                                    repos=repo_urls,
-                                   scratch=True,
+                                   scratch=scratch,
                                    koji_parent_build=parent)
     # Show information to the console.
     koji.watch_task(task_id)
@@ -176,6 +176,8 @@ def parse_args():
     parser.add_argument('--compose', required=False,
                         default=compose_url_from_env(),
                         help='HTTP(S) URL to a product Pungi compose.')
+    parser.add_argument('--scratch', default=True, action='store_true',
+                        help='scratch-build container image')
     return parser.parse_args()
 
 
@@ -218,7 +220,8 @@ def main():
     repo_urls.add(repo_url)
 
     # Do a Koji build
-    metadata = build_container(repo_urls, branch, parent_image, configp)
+    metadata = build_container(repo_urls, branch, parent_image, args.scratch,
+                               configp)
 
     # Publish this Koji build to our registry
     container_pub = get_container_publisher(configp)

--- a/bucko/tests/test_init.py
+++ b/bucko/tests/test_init.py
@@ -123,7 +123,9 @@ class TestBuildContainer(object):
         repo_url = 'http://example.com/example.repo'
         branch = 'foo-3.0-rhel-7'
         parent_image = None
-        results = bucko.build_container(repo_url, branch, parent_image, config)
+        scratch = True
+        results = bucko.build_container(repo_url, branch, parent_image,
+                                        scratch, config)
         assert results['koji_task'] == 1234
         assert results['repository'] == 'http://registry.example.com/foo'
 


### PR DESCRIPTION
Add a `--scratch` flag to the bucko CLI.

Note, since this has `default=True`, bucko's behavior does not change if the user specifies `--scratch` or not.

The purpose of this change without making it effective is so that we can seamlessly begin using this flag in Jenkins.