### PR TITLE
untag non-scratch builds

### DIFF
--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -157,6 +157,12 @@ def build_container(repo_urls, branch, parent_image, scratch, configp):
     # Show information to the console.
     koji.watch_task(task_id)
 
+    # Untag the build from the -candidate tag:
+    # There's no "skip_tag" parameter for buildContainer, so we must
+    # immediately untag it ourselves.
+    if not scratch:
+        koji.untag_task_result(task_id)
+
     # Return information about this build.
     result = {'koji_task': task_id}
 

--- a/bucko/koji_builder.py
+++ b/bucko/koji_builder.py
@@ -72,3 +72,20 @@ class KojiBuilder(object):
         """ Get the list of repositories for a container task. """
         result = self.session.getTaskResult(id_)
         return result['repositories']
+
+    def untag_task_result(self, task_id):
+        """ Untag the builds from this buildContainer task. """
+        result = self.session.getTaskResult(task_id)
+        build_ids = result['koji_builds']
+        for build_id in build_ids:
+            build_id = int(build_id)  # koji returns strs for some reason
+            weburl = self.session.opts['weburl']
+            url = posixpath.join(weburl, 'buildinfo?buildID=%s' % build_id)
+            print('Checking %s for tags to untag' % url)
+            tags = self.session.listTags(build=build_id)
+            if tags:
+                self.ensure_logged_in()
+            for tag in tags:
+                tag_name = tag['name']
+                print('Untagging %s from %s' % (url, tag_name))
+                self.session.untagBuild(tag_name, build_id, strict=False)


### PR DESCRIPTION
If we build a container with Bucko, we do not want these builds in Koji's -candidate tag or anything else. We want to garbage-collect these relatively quickly.