### PR TITLE
always write "repository" JSON key with unique tag

### DIFF
--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -166,11 +166,9 @@ def build_container(repo_urls, branch, parent_image, scratch, configp):
     # Return information about this build.
     result = {'koji_task': task_id}
 
-    # Collapse "repositories" to "repository" if there was only one for
-    # simplicity.
-    repositories = koji.get_repositories(task_id)
-    if len(repositories) == 1:
-        result['repository'] = repositories[0]
+    repositories = koji.get_repositories(task_id, kconf['target'])
+    # "repository" (first in the list) is the OSBS unique tag.
+    result['repository'] = repositories[0]
     result['repositories'] = repositories
 
     return result

--- a/bucko/tests/test_koji_builder.py
+++ b/bucko/tests/test_koji_builder.py
@@ -63,6 +63,11 @@ class FakeClientSession(object):
         """ Return a non-scratch buildContainer task result """
         return {
             'koji_builds': ['1234'],  # list of koji build IDs
+            'repositories': [
+                'registry.example.com/ceph:5',
+                'registry.example.com/ceph:ceph-candidate-123-45678',
+                'registry.example.com/ceph:5-1',
+            ],
         }
 
     def listTags(self, build):
@@ -99,6 +104,16 @@ class TestKojiBuilder(object):
         k.watch_task(1234, interval=0)
         out, _ = capsys.readouterr()
         assert 'Watching Koji task dummyweb/taskinfo?taskID=1234' in out
+
+    def test_get_repositories(self, monkeypatch, capsys):
+        monkeypatch.setattr('bucko.koji_builder.koji', FakeKoji)
+        k = KojiBuilder('koji')
+        repos = k.get_repositories(12345, 'ceph-candidate')
+        assert repos == [
+            'registry.example.com/ceph:ceph-candidate-123-45678',
+            'registry.example.com/ceph:5',
+            'registry.example.com/ceph:5-1',
+        ]
 
     def test_untag_task_result(self, monkeypatch, capsys):
         monkeypatch.setattr('bucko.koji_builder.koji', FakeKoji)


### PR DESCRIPTION
Prior to this change, non-scratch builds would not result in a `repository` key in the JSON record. Bucko would only write this key if there was a single repo from OSBS. Non-scratch builds have more than one repo (tag).

Update Bucko to always write a `repository` key in the JSON data, regardless of the number of repositories OSBS presents.

Always write the unique repo (tag) into this key, so that we do not emphasize OSBS' floating tags for QE.

Fixes: #46