### PR TITLE
config: gracefully handle missing product configurations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,8 +236,10 @@ Bucko will interpolate the ``%(branch)s`` format string according to the
 compose's metadata. For example, bucko will choose a ``branch`` value of
 ``ceph-3.0-rhel-7`` when processing a ``RHCEPH 3.0`` compose.
 
-The ``[*-base]`` sections are unique per branch. Please define one for each
-branch you expect to use.
+The ``[*-base]`` sections are optional and unique per branch. If you define
+one for your branch, bucko will add the repo files to the container build. If
+you do not define one for your branch, bucko will add no additional Yum repos
+to the build beyond the repos from the compose itself.
 
 The ``parent_image`` setting in each branch is optional. Define this in order
 to override the parent image. If this is not set, Bucko/OSBS will use the

--- a/bucko/config.py
+++ b/bucko/config.py
@@ -31,10 +31,14 @@ def get_repo_urls(configp, section):
     """
     Return a set of URLs for this configparser section.
 
+    If this section does not exist, return an empty set.
+
     :param str section: eg. 'ceph-3.0-rhel-7-base'
     :returns: set of URLs for Yum .repo files
     """
     urls = set()
+    if section not in configp.sections():
+        return urls
     items = configp.items(section)
     for key, url in items:
         if not key.startswith('repo'):

--- a/bucko/tests/test_config.py
+++ b/bucko/tests/test_config.py
@@ -53,3 +53,9 @@ def test_get_repo_urls(configp):
     expected = set(['http://example.com/repo1.repo',
                     'http://example.com/repo2.repo'])
     assert result == expected
+
+
+def test_get_repo_urls_empty(configp):
+    section = 'ceph-norepos-rhel-8-base'
+    result = config.get_repo_urls(configp, section)
+    assert result == set()


### PR DESCRIPTION
With RHCS 5+, we use ODCS (with Pulp repos) in order to install RHEL RPMs, so we don't need to pass in our own Yum repository definitions for RHEL.

All the `[ceph-x.y-rhel-8-base]` sections end up looking identical now, and there is no point to defining them explicitly any more.

Update `get_repo_urls()` to gracefully handle the case where there is no `[ceph-x.y-rhel-8-base]` section. In those cases, bucko will simply add no additional repositories.

Fixes: #42 