### PR TITLE
add odcs_tag feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -246,6 +246,13 @@ to override the parent image. If this is not set, Bucko/OSBS will use the
 "FROM" line in the Dockerfile. This ``parent_image`` setting is useful if you
 want to build a container dist-git branch against a yet-unreleased base image.
 
+The ``odcs_tag`` setting in each branch is optional. Define this in order to
+make an additional tag's RPMs available during your container build. This
+mimics how OSBS generates ODCS composes from Koji's build targets, but it
+provides more flexibility. For example, to add your ``-candidate`` tag's RPMs
+to Bucko's CI builds without affecting other container builds (eg. release
+candidates), use this option.
+
 The ``registry_url`` setting in ``[publisher]`` is optional. Define this in
 order to publish the scratch images to a separate registry. For example, if
 the branch for the compose was ``ceph-4.0-rhel-8``, bucko will publish each

--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -5,6 +5,7 @@ import json
 import os
 from .log import log
 from bucko import config
+from bucko import odcs_manager
 from bucko.container_publisher import ContainerPublisher
 from bucko.repo_compose import RepoCompose
 from bucko.publisher import Publisher
@@ -223,6 +224,12 @@ def main():
     for url in repo_urls:
         log.info('Additional .repo configured: %s' % url)
     repo_urls.add(repo_url)
+    odcs_tag = config.lookup(configp, section, 'odcs_tag', fatal=False)
+    if odcs_tag:
+        log.info('odcs_tag configured: %s' % odcs_tag)
+        odcs_repo_url = odcs_manager.generate(odcs_tag)
+        log.info('Adding odcs repo url %s' % odcs_repo_url)
+        repo_urls.add(odcs_repo_url)
 
     # Do a Koji build
     metadata = build_container(repo_urls, branch, parent_image, args.scratch,

--- a/bucko/odcs_manager.py
+++ b/bucko/odcs_manager.py
@@ -1,0 +1,20 @@
+from bucko.log import log
+from odcs.client import odcs
+
+# TODO: determine the arches dynamically from the
+# ceph-6.0-rhel-9-containers-candidate target tag, like OSBS does.
+ARCHES = ['x86_64', 'ppc64le', 's390x']
+ODCS_URL = 'https://odcs.engineering.redhat.com'
+
+
+def generate(tag):
+    # On CLI:
+    # odcs --quiet --redhat create-tag --arch "x86_64 ppc64le s390x" --sigkey none ceph-6.0-rhel-9-candidate
+    source = odcs.ComposeSourceTag(tag, sigkeys=[''])
+    client = odcs.ODCS(ODCS_URL, auth_mech=odcs.AuthMech.Kerberos)
+    compose = client.request_compose(source, arches=ARCHES)
+    log.info('waiting for %s to finish' % compose['toplevel_url'])
+    result = client.wait_for_compose(compose['id'])
+    if result['state_name'] != 'done':
+        raise RuntimeError(result)
+    return result['result_repofile']

--- a/bucko/tests/test_odcs_manager.py
+++ b/bucko/tests/test_odcs_manager.py
@@ -13,6 +13,9 @@ def test_generate(mock_wait, mock_request):
     assert result == 'https://example.com/example.repo'
 
     mock_request.assert_called_once()
+    # py36 compat for .call_args properties:
+    mock_request.call_args.args = mock_request.call_args[0]
+    mock_request.call_args.kwargs = mock_request.call_args[1]
     source = mock_request.call_args.args[0]
     assert isinstance(source, ComposeSourceTag)
     kwargs = mock_request.call_args.kwargs

--- a/bucko/tests/test_odcs_manager.py
+++ b/bucko/tests/test_odcs_manager.py
@@ -1,0 +1,19 @@
+from odcs.client.odcs import ComposeSourceTag
+from bucko import odcs_manager
+from unittest.mock import patch
+
+
+@patch('bucko.odcs_manager.odcs.ODCS.request_compose',
+       return_value={'id': 1, 'toplevel_url': 'http://example.com/'})
+@patch('bucko.odcs_manager.odcs.ODCS.wait_for_compose',
+       return_value={'state_name': 'done',
+                     'result_repofile': 'https://example.com/example.repo'})
+def test_generate(mock_wait, mock_request):
+    result = odcs_manager.generate('ceph-6.0-rhel-9-candidate')
+    assert result == 'https://example.com/example.repo'
+
+    mock_request.assert_called_once()
+    source = mock_request.call_args.args[0]
+    assert isinstance(source, ComposeSourceTag)
+    kwargs = mock_request.call_args.kwargs
+    assert kwargs == {'arches': ['x86_64', 'ppc64le', 's390x']}

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'koji',
+        'odcs[client]',
         'paramiko',
         'productmd>=1.3',
     ],


### PR DESCRIPTION
Add in more tags' RPMs with `odcs_tag` option. We will use this to add the RPMs from our `-candidate` tags.