### PR TITLE
tests: fix call_args compatibility handling

### DIFF
--- a/bucko/tests/test_odcs_manager.py
+++ b/bucko/tests/test_odcs_manager.py
@@ -1,3 +1,4 @@
+import sys
 from odcs.client.odcs import ComposeSourceTag
 from bucko import odcs_manager
 from unittest.mock import patch
@@ -13,9 +14,10 @@ def test_generate(mock_wait, mock_request):
     assert result == 'https://example.com/example.repo'
 
     mock_request.assert_called_once()
-    # py36 compat for .call_args properties:
-    mock_request.call_args.args = mock_request.call_args[0]
-    mock_request.call_args.kwargs = mock_request.call_args[1]
+    if sys.version_info < (3, 8):
+        # compat for .call_args properties:
+        mock_request.call_args.args = mock_request.call_args[0]
+        mock_request.call_args.kwargs = mock_request.call_args[1]
     source = mock_request.call_args.args[0]
     assert isinstance(source, ComposeSourceTag)
     kwargs = mock_request.call_args.kwargs


### PR DESCRIPTION
In py38+, we cannot assign `.args` or `.kwargs`. Those are `@property` methods. Only apply the backwards compat assignments on Python older than 3.8.