### PR TITLE
registry: load Labels from config key

### DIFF
--- a/bucko/registry.py
+++ b/bucko/registry.py
@@ -118,7 +118,7 @@ class Registry(object):
         # repository: image repository name, eg. "rhel7"
         # reference: tag name in the repository, eg. "7.5-ondeck"
         data = self.config(repository, reference)
-        labels = data['container_config']['Labels']
+        labels = data['config']['Labels']
         return Build(labels['com.redhat.component'],
                      labels['version'],
                      labels['release'])


### PR DESCRIPTION
The `Labels` data is available under a different key now. (Maybe this is related to the latest schema support? see commit cb0cbd9f4898c03b745602710a4187531270240a)