### PR TITLE
publisher: fall back to old sha1 RSA pubkeys

### DIFF
--- a/bucko/publisher.py
+++ b/bucko/publisher.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     from urlparse import urlparse
 import os
-from paramiko import SSHClient
+import paramiko
 import shutil
 
 """
@@ -35,7 +35,7 @@ class Publisher(object):
         """ Publish a file to an SFTP server. """
         url = urlparse(self.push_url)
         destfile = os.path.join(url.path, os.path.basename(file_))
-        ssh = SSHClient()
+        ssh = paramiko.SSHClient()
         ssh.load_system_host_keys()
         # ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         ssh.connect(url.netloc.split('@')[-1], username=url.username)

--- a/bucko/publisher.py
+++ b/bucko/publisher.py
@@ -39,8 +39,12 @@ class Publisher(object):
         ssh.load_system_host_keys()
         host = url.netloc.split('@')[-1]
         # ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(host, username=url.username)
-
+        try:
+            ssh.connect(host, username=url.username)
+        except paramiko.ssh_exception.AuthenticationException:
+            ssh.connect(host, username=url.username,
+                        disabled_algorithms={'pubkeys': ["rsa-sha2-512",
+                                                         "rsa-sha2-256"]})
         sftp = ssh.open_sftp()
         sftp.put(file_, destfile)
         sftp.close()

--- a/bucko/publisher.py
+++ b/bucko/publisher.py
@@ -37,8 +37,9 @@ class Publisher(object):
         destfile = os.path.join(url.path, os.path.basename(file_))
         ssh = paramiko.SSHClient()
         ssh.load_system_host_keys()
+        host = url.netloc.split('@')[-1]
         # ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(url.netloc.split('@')[-1], username=url.username)
+        ssh.connect(host, username=url.username)
 
         sftp = ssh.open_sftp()
         sftp.put(file_, destfile)

--- a/bucko/tests/test_publisher.py
+++ b/bucko/tests/test_publisher.py
@@ -30,7 +30,7 @@ class TestPublisher(object):
 
     def test_sftp(self, monkeypatch):
         """ Test publishing with an sftp:// URL """
-        monkeypatch.setattr('bucko.publisher.SSHClient', FakeSSHClient)
+        monkeypatch.setattr('bucko.publisher.paramiko.SSHClient', FakeSSHClient)
         p = Publisher(PUSH_URL, HTTP_URL)
         result = p.publish('test.repo')
         assert result == posixpath.join(HTTP_URL, 'test.repo')


### PR DESCRIPTION
When Paramiko 2.9+ connects to sshd on RHEL 6, it tries `rsa-sha2` and fails.

Try the connection without disabling any algorithms first. If that fails, re-try it with `rsa-sha2` disabled.

With this PR, Paramiko 2.9+ can connect to both RHEL 6 and RHEL 9.