### PR TITLE
publisher: refactor paramiko usage

### DIFF
--- a/bucko/publisher.py
+++ b/bucko/publisher.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     from urlparse import urlparse
 import os
-from paramiko import SSHClient
+import paramiko
 import shutil
 
 """
@@ -35,7 +35,7 @@ class Publisher(object):
         """ Publish a file to an SFTP server. """
         url = urlparse(self.push_url)
         destfile = os.path.join(url.path, os.path.basename(file_))
-        ssh = SSHClient()
+        ssh = paramiko.SSHClient()
         ssh.load_system_host_keys()
         # ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         ssh.connect(url.netloc.split('@')[-1], username=url.username)

--- a/bucko/publisher.py
+++ b/bucko/publisher.py
@@ -37,8 +37,9 @@ class Publisher(object):
         destfile = os.path.join(url.path, os.path.basename(file_))
         ssh = paramiko.SSHClient()
         ssh.load_system_host_keys()
+        host = url.netloc.split('@')[-1]
         # ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(url.netloc.split('@')[-1], username=url.username)
+        ssh.connect(host, username=url.username)
 
         sftp = ssh.open_sftp()
         sftp.put(file_, destfile)

--- a/bucko/tests/test_publisher.py
+++ b/bucko/tests/test_publisher.py
@@ -30,7 +30,7 @@ class TestPublisher(object):
 
     def test_sftp(self, monkeypatch):
         """ Test publishing with an sftp:// URL """
-        monkeypatch.setattr('bucko.publisher.SSHClient', FakeSSHClient)
+        monkeypatch.setattr('bucko.publisher.paramiko.SSHClient', FakeSSHClient)
         p = Publisher(PUSH_URL, HTTP_URL)
         result = p.publish('test.repo')
         assert result == posixpath.join(HTTP_URL, 'test.repo')


### PR DESCRIPTION
This PR takes the refactoring commits from https://github.com/red-hat-storage/bucko/pull/57, but it does not include any functional behavior change. That PR disabled `rsa-sha2`, but this does not.

I found the code reorg to be generally useful, and it makes it easier to read and debug.
