### PR TITLE
registry: add signature querying

### DIFF
--- a/bucko/registry.py
+++ b/bucko/registry.py
@@ -151,13 +151,51 @@ class Registry(object):
         username_password = base64.b64decode(auth).decode()
         return username_password.split(':', 1)
 
-    def _get(self, repository, endpoint):
+    @property
+    def lookaside(self):
+        """
+        Read the lookaside (or sigstore) URL from /etc/containers/registry.d/
+
+        See
+        https://github.com/containers/image/blob/main/docs/signature-protocols.md
+        for details. This used to be called "sigstore" in RHEL 8.
+
+        Example:
+        https://registry.redhat.io/containers/sigstore/
+
+        :returns: the sigstore URL string, or None
+        """
+        # bucko's main use-case does not exercise the signature codepaths yet.
+        # For flexibility and simplicity, I'm importing this dependency here,
+        # so you only need to install PyYAML if you're checking signatures.
+        import yaml
+        o = urlparse(self.baseurl)
+        hostname = o.hostname
+        conf = f'/etc/containers/registries.d/{hostname}.yaml'
+        try:
+            with open(conf) as f:
+                data = yaml.safe_load(f)
+        except FileNotFoundError:
+            return None
+        docker = data.get('docker')
+        if not docker:
+            return None
+        host = docker.get(hostname)
+        if not host:
+            return None
+        lookaside = host.get('lookaside')
+        if lookaside:
+            return lookaside
+        return host.get('sigstore')
+
+    def _get(self, repository, endpoint, additional_headers={}):
         """
         Get a docker distribution API endpoint URL.
 
         :param str repository: repository we want to query eg. "rhel7"
         :param str path: API endpoint for this repository, eg.
                          "manifests/7.5-ondeck"
+        :param dict additional_headers: Add these headers to the request
         :returns: Response object
         """
         url = posixpath.join(self.baseurl, repository, endpoint)
@@ -167,8 +205,9 @@ class Registry(object):
             if r.status_code == 401:
                 (realm, service) = self.find_realm_service(r)
                 self.store_token(realm, service, repository)
-                return self._get(repository, endpoint)
+                return self._get(repository, endpoint, additional_headers)
         headers = {'Authorization': 'Bearer %s' % token}
+        headers.update(additional_headers)
         r = self.session.get(url, headers=headers)
         r.raise_for_status()
         return r
@@ -189,13 +228,113 @@ class Registry(object):
                      labels['version'],
                      labels['release'])
 
-    def manifest(self, repository, reference):
+    def signatures(self, image):
+        """
+        Return the GPG signature data for this image.
+
+        See
+        https://github.com/containers/image/blob/main/docs/containers-signature.5.md
+        and
+        https://github.com/containers/image/blob/main/docs/signature-protocols.md
+
+        :param str image: image name, eg. "cp/ibm-ceph/ceph-5-rhel8:latest"
+        :returns: list of signatures for this image's manifest sha256 digest.
+                  Note that one manifest digest can have multiple tags.
+        """
+        # Lots of duplicated code here...
+        (repository, reference) = image.split(':', 1)
+        manifests = self.manifest(repository, reference, manifest_list=True)
+        for manifest in manifests['manifests']:
+            platform = manifest['platform']
+            # hard-coding so we only return signatures for one arch...
+            if platform['architecture'] != 'amd64':
+                continue
+            digest = manifest['digest']
+
+        signatures = []
+        if self.lookaside:
+            # Use that URL + /signature-1, 2, 3, etc. until you hit a 404.
+            # The resulting data is the gpg-signed JSON blob.
+            template = posixpath.join(
+                self.lookaside,
+                repository + '@' + digest.replace(':', '='),
+                'signature-{index}'
+            )
+            index = 1
+            MAX_SIGNATURES = 25  # sanity circuit breaker
+            while index < MAX_SIGNATURES:
+                url = template.format(index=index)
+                response = self.session.get(url)
+                if response.ok:
+                    signatures.append(response.content)
+                    index += 1
+                else:
+                    break
+        else:
+            # No /etc/containers/registries.d for this host.
+            # Query the default "extensions" URL on this registry.
+            token = self.tokens[repository]
+            headers = {'Authorization': 'Bearer %s' % token}
+            baseurl = self.baseurl.replace('/v2', '/extensions/v2')
+            url = posixpath.join(baseurl, repository, 'signatures', digest)
+            r = self.session.get(url, headers=headers)
+            if r.status_code == 404:
+                return []
+            r.raise_for_status()
+            data = r.json()
+            for entry in data['signatures']:
+                # "content" is the base64-encoded GPG binary blob.
+                signature = base64.b64decode(entry['content'])
+                signatures.append(signature)
+        return signatures
+
+    def signature_payloads(self, image):
+        """
+        Return the JSON document payloads that GPG has signed.
+
+        Ignores GPG signature validity and simply returns the data.
+
+        :returns: list of dicts, one per signature/ref
+        """
+        # Pipe each binary file thru /usr/bin/gpg to read the contents
+        # on STDOUT and view the signature info on STDERR
+        # Or, run gpg --verify /tmp/myfile to only verify the signature.
+        payloads = []
+        from subprocess import Popen, PIPE
+        signatures = self.signatures(image)
+        for signature in signatures:
+            p = Popen(['gpg'], stdout=PIPE, stdin=PIPE, stderr=PIPE)
+            stdout_data = p.communicate(input=signature)[0]
+            string = stdout_data.decode()
+            payload = json.loads(string)
+            payloads.append(payload)
+        return payloads
+
+    def signature_references(self, image):
+        """
+        Return all the docker refs (tags) that are signed for this container
+        image.
+
+        Ignores GPG signature validity and simply returns the list of refs.
+
+        :returns: list of docker refs (str)
+        """
+        signatures = self.signature_payloads(image)  # bucko.build.Build
+        return [s['critical']['identity']['docker-reference']
+                for s in signatures]
+
+    def manifest(self, repository, reference, manifest_list=False):
         """
         Get the manifest information about this image.
 
         :param str repository: repository to query, eg "rhel7"
         :param str reference: tag name in the repository, "7.5-ondeck"
+        :param bool manifest_list: return the "fat manifests", see
+                                   https://docs.docker.com/registry/spec/manifest-v2-2/
         """
         endpoint = 'manifests/%s' % reference
-        r = self._get(repository, endpoint)
+        additional_headers = {}
+        if manifest_list:
+            additional_headers['Accept'] = 'application/vnd.docker.distribution.manifest.list.v2+json'
+        r = self._get(repository, endpoint, additional_headers)
         return r.json()


### PR DESCRIPTION
`bucko.registry` is a useful standalone module to perform authenticated, read-only queries against container registries. This commit adds GPG signature querying and processing.

Nothing in Bucko exercises this code at the moment. I've just found it useful when comparing container signatures across Red Hat and IBM.