### PR TITLE
registry: support REGISTRY_AUTH_FILE if available

### DIFF
--- a/bucko/registry.py
+++ b/bucko/registry.py
@@ -117,7 +117,9 @@ class Registry(object):
 
     @property
     def authfile(self):
-        # skopeo requires XDG_RUNTIME_DIR
+        if os.getenv('REGISTRY_AUTH_FILE'):
+            return os.environ['REGISTRY_AUTH_FILE']
+        # skopeo requires XDG_RUNTIME_DIR if REGISTRY_AUTH_FILE is unset,
         # https://github.com/containers/image/issues/1097
         # For simplicity we will require it also.
         if not os.getenv('XDG_RUNTIME_DIR'):


### PR DESCRIPTION
`podman`, `skopeo`, and `oc` will load credentials from the `REGISTRY_AUTH_FILE` environment variable if that is set. Add support for this to our `Registry` class.

This is another feature that we don't use in Bucko today (Red Hat's registry-proxy is unauthenticated), but it's a generally useful feature for when we extract this class into to standalone pure Python registry library.