### PR TITLE
repo_compose: hack for plaintext http

### DIFF
--- a/bucko/repo_compose.py
+++ b/bucko/repo_compose.py
@@ -85,6 +85,8 @@ class RepoCompose(productmd.compose.Compose):
             url = self.get_variant_url(variant, arch)
             # XXX Terrible hack ahead:
             url = url.replace('x86_64', '$basearch')
+            # XXX Hack for CLOUDWF-10277:
+            url = url.replace('https://', 'http://')
             gpgkey = self.get_variant_gpg_key(variant, arch)
             config.add_section(name)
             config.set(name, 'name', self.info.compose.id + ' ' + uid)

--- a/bucko/tests/test_repo_compose.py
+++ b/bucko/tests/test_repo_compose.py
@@ -57,3 +57,16 @@ class TestRepoComposeYumRepo(object):
                     'MYPRODUCT-2.1-RHEL-7-OSD',
                     'MYPRODUCT-2.1-RHEL-7-Tools']
         assert config.sections() == expected
+
+    def test_baseurl(self, repocompose, monkeypatch):
+        """ Test a web URL """
+        monkeypatch.setattr(repocompose, 'get_variant_url',
+                            lambda variant, arch:
+                            f'https://noexist.example.com/composes/{variant}')
+        path = repocompose.write_yum_repo_file()
+        # Verify the contents with ConfigParser
+        config = RawConfigParser()
+        config.read(path)
+        result = config.get('MYPRODUCT-2.1-RHEL-7-Tools', 'baseurl')
+        expected = 'https://noexist.example.com/composes/Tools'
+        assert result == expected

--- a/bucko/tests/test_repo_compose.py
+++ b/bucko/tests/test_repo_compose.py
@@ -68,5 +68,6 @@ class TestRepoComposeYumRepo(object):
         config = RawConfigParser()
         config.read(path)
         result = config.get('MYPRODUCT-2.1-RHEL-7-Tools', 'baseurl')
-        expected = 'https://noexist.example.com/composes/Tools'
+        # XXX: hack for CLOUDWF-10277, this is plaintext http:
+        expected = 'http://noexist.example.com/composes/Tools'
         assert result == expected


### PR DESCRIPTION
The new iad2 web server does not serve HTTPS to OSBS. We have to go back to HTTP.

This is a workaround for [CLOUDWF-10277](https://issues.redhat.com/browse/CLOUDWF-10277).
