### PR TITLE
Revert "repo_compose: hack for plaintext http"

### DIFF
--- a/bucko/repo_compose.py
+++ b/bucko/repo_compose.py
@@ -85,8 +85,6 @@ class RepoCompose(productmd.compose.Compose):
             url = self.get_variant_url(variant, arch)
             # XXX Terrible hack ahead:
             url = url.replace('x86_64', '$basearch')
-            # XXX Hack for CLOUDWF-10277:
-            url = url.replace('https://', 'http://')
             gpgkey = self.get_variant_gpg_key(variant, arch)
             config.add_section(name)
             config.set(name, 'name', self.info.compose.id + ' ' + uid)

--- a/bucko/tests/test_repo_compose.py
+++ b/bucko/tests/test_repo_compose.py
@@ -68,6 +68,5 @@ class TestRepoComposeYumRepo(object):
         config = RawConfigParser()
         config.read(path)
         result = config.get('MYPRODUCT-2.1-RHEL-7-Tools', 'baseurl')
-        # XXX: hack for CLOUDWF-10277, this is plaintext http:
-        expected = 'http://noexist.example.com/composes/Tools'
+        expected = 'https://noexist.example.com/composes/Tools'
         assert result == expected


### PR DESCRIPTION
Two changes are in place now:

1) OSBS permits unproxied HTTPS connections to the new download server (CLOUDWF-10277).

2) UMB messages have plaintext HTTP compose URLs again (CWFCONF-9552). This enables QE testing.

This reverts commit 56f19031ea33d4b308b38d604e0046d21365b7fb.