### PR TITLE
search koji for list of arches for odcs

### DIFF
--- a/bucko/__init__.py
+++ b/bucko/__init__.py
@@ -224,10 +224,14 @@ def main():
     for url in repo_urls:
         log.info('Additional .repo configured: %s' % url)
     repo_urls.add(repo_url)
+
     odcs_tag = config.lookup(configp, section, 'odcs_tag', fatal=False)
     if odcs_tag:
         log.info('odcs_tag configured: %s' % odcs_tag)
-        odcs_repo_url = odcs_manager.generate(odcs_tag)
+        kconf = dict(configp.items('koji', vars={'branch': branch}))
+        koji = KojiBuilder(profile=kconf['profile'])
+        arches = koji.get_target_arches(kconf['target'])
+        odcs_repo_url = odcs_manager.generate(odcs_tag, arches)
         log.info('Adding odcs repo url %s' % odcs_repo_url)
         repo_urls.add(odcs_repo_url)
 

--- a/bucko/koji_builder.py
+++ b/bucko/koji_builder.py
@@ -110,3 +110,15 @@ class KojiBuilder(object):
                 tag_name = tag['name']
                 print('Untagging %s from %s' % (url, tag_name))
                 self.session.untagBuild(tag_name, build_id, strict=False)
+
+    def get_target_arches(self, target):
+        """
+        Return the arches for a Koji build target.
+
+        :param str target: eg. ceph-8.0-rhel-9-containers-candidate
+        :returns: a space-separated list, like "x86_64 ppc64le s390x aarch64".
+        """
+        result = self.session.getBuildTarget(target, strict=True)
+        build_tag = result['build_tag']
+        tag = self.session.getTag(build_tag, strict=True)
+        return tag['arches']

--- a/bucko/odcs_manager.py
+++ b/bucko/odcs_manager.py
@@ -1,18 +1,16 @@
 from bucko.log import log
 from odcs.client import odcs
 
-# TODO: determine the arches dynamically from the
-# ceph-6.0-rhel-9-containers-candidate target tag, like OSBS does.
-ARCHES = ['x86_64', 'ppc64le', 's390x']
 ODCS_URL = 'https://odcs.engineering.redhat.com'
 
 
-def generate(tag):
+def generate(tag, arches):
     # On CLI:
     # odcs --quiet --redhat create-tag --arch "x86_64 ppc64le s390x" --sigkey none ceph-6.0-rhel-9-candidate
+    # odcs --quiet --redhat create-tag --arch "x86_64 ppc64le s390x aarch64" --sigkey none ceph-8.0-rhel-9-candidate
     source = odcs.ComposeSourceTag(tag, sigkeys=[''])
     client = odcs.ODCS(ODCS_URL, auth_mech=odcs.AuthMech.Kerberos)
-    compose = client.request_compose(source, arches=ARCHES)
+    compose = client.request_compose(source, arches=arches.split())
     log.info('waiting for %s to finish' % compose['toplevel_url'])
     result = client.wait_for_compose(compose['id'])
     if result['state_name'] != 'done':

--- a/bucko/tests/test_koji_builder.py
+++ b/bucko/tests/test_koji_builder.py
@@ -40,11 +40,14 @@ class FakeClientSession(object):
     def getAPIVersion(self):
         return 1
 
-    def getBuildTarget(self, target):
-        return {}
+    def getBuildTarget(self, target, strict=False):
+        return {'build_tag': 123}
 
     def buildContainer(self, *args, **kw):
         return 1234
+
+    def getTag(self, tag, strict=False):
+        return {'arches': 'x86_64 ppc64le s390x'}
 
     def getTaskInfo(self, id_, request=False):
         """ Return 'OPEN' state the first couple of times, then 'CLOSED'. """
@@ -125,3 +128,10 @@ Checking dummyweb/buildinfo?buildID=1234 for tags to untag
 Untagging dummyweb/buildinfo?buildID=1234 from ceph-candidate
 """
         assert out == expected
+
+    def test_get_target_arches(self, monkeypatch, capsys):
+        monkeypatch.setattr('bucko.koji_builder.koji', FakeKoji)
+        k = KojiBuilder('koji')
+        target = 'ceph-7.0-rhel-9-containers-candidate'
+        result = k.get_target_arches(target)
+        assert result == 'x86_64 ppc64le s390x'

--- a/bucko/tests/test_odcs_manager.py
+++ b/bucko/tests/test_odcs_manager.py
@@ -10,7 +10,8 @@ from unittest.mock import patch
        return_value={'state_name': 'done',
                      'result_repofile': 'https://example.com/example.repo'})
 def test_generate(mock_wait, mock_request):
-    result = odcs_manager.generate('ceph-6.0-rhel-9-candidate')
+    result = odcs_manager.generate('ceph-6.0-rhel-9-candidate',
+                                   'x86_64 ppc64le s390x')
     assert result == 'https://example.com/example.repo'
 
     mock_request.assert_called_once()


### PR DESCRIPTION
Prior to this change, we hard-coded a list of architectures in `odcs_manager`. When we added aarch64 to the product, Bucko did not generate an aarch64 repository in ODCS, so the container builds failed for aarch64.

Remove the hard-coded list of arches in `odcs_manager`. Look up the list of arches on the Koji target's build tag instead, and pass that into `odcs_manager.generate()`. This matches how OSBS itself generates ODCS composes.